### PR TITLE
fixed misspelling of function in else statement

### DIFF
--- a/Az/Invoke-AzHybridWorkerExtraction.ps1
+++ b/Az/Invoke-AzHybridWorkerExtraction.ps1
@@ -63,7 +63,7 @@ function Invoke-AzHybridWorkerExtraction{
         # List subscriptions, pipe out to gridview selection
         $Subscriptions = Get-AzSubscription -WarningAction SilentlyContinue
         $subChoice = $Subscriptions | out-gridview -Title "Select One or More Subscriptions" -PassThru
-        foreach ($sub in $subChoice) {Invoke-HybridWorkerExtraction -Subscription $sub}
+        foreach ($sub in $subChoice) {Invoke-AzHybridWorkerExtraction -Subscription $sub}
         break
     }
 


### PR DESCRIPTION
Line 66 should be `foreach ($sub in $subChoice) {Invoke-AzHybridWorkerExtraction -Subscription $sub}` but in the current version it is `foreach ($sub in $subChoice) {Invoke-HybridWorkerExtraction -Subscription $sub}` and powershell can't find the function Invoke-HybridWorkerExtraction as it does not exist