### PR TITLE
Added function to enable Elevated Access Toggle

### DIFF
--- a/REST/Invoke-AzElevatedAccessToggle.ps1
+++ b/REST/Invoke-AzElevatedAccessToggle.ps1
@@ -1,0 +1,23 @@
+Function Invoke-AzElevatedAccessToggle {
+
+    # Author: Karim El-Melhaoui(@KarimMelhaoui), O3 Cyber
+    # Description: PowerShell function for invoking Elevated Access Toggle
+    # https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin 
+    # https://microsoft.github.io/Azure-Threat-Research-Matrix/PrivilegeEscalation/AZT402/AZT402/
+
+    try {
+
+        $Token = Get-AzAccessToken
+        $Headers = @{Authorization = "Bearer $($Token.Token)" }
+        $ElevatedAccessToggle = Invoke-RestMethod -Method POST -Uri "https://management.azure.com/providers/Microsoft.Authorization/elevateAccess?api-version=2016-07-01" -Headers $Headers
+
+        $ElevatedAccessToggle
+        Write-Output "Granting current principal at User Access Administrator at  Root level."
+        
+    }
+    catch {
+        Write-Output "Something went wrong. : $_"
+        Write-Output "`nThis is likely because the principal is not Global Administrator."
+    }
+
+}


### PR DESCRIPTION
Added a simple function to enable Elevated Access Toggle to allow going from Global Administrator to User Access Administrator at all associated Azure subscriptions.

The motivation for this is that the technique is part of the Azure Threat Research Matrix:
https://microsoft.github.io/Azure-Threat-Research-Matrix/PrivilegeEscalation/AZT402/AZT402/