### PR TITLE
Get-AzPasswords: fix several errors preventing Automation credentials gathering

### DIFF
--- a/Az/Get-AzPasswords.ps1
+++ b/Az/Get-AzPasswords.ps1
@@ -598,6 +598,7 @@ Function Get-AzPasswords
                         "`$base64string = [Convert]::ToBase64String([IO.File]::ReadAllBytes(`$CertificatePath))" | Out-File -FilePath "$pwd\$jobName.ps1" -Append
 
                         # Copy the B64 encryption cert to the Automation Account host
+                        "New-Item -ItemType Directory -Force -Path `"C:\Temp`" | Out-Null" | Out-File -FilePath "$pwd\$jobName.ps1" -Append
                         "`$FileName = `"C:\Temp\microburst.cer`"" | Out-File -FilePath "$pwd\$jobName.ps1" -Append
                         "[IO.File]::WriteAllBytes(`$FileName, [Convert]::FromBase64String(`"$ENCbase64string`"))" | Out-File -FilePath "$pwd\$jobName.ps1" -Append
                         "Import-Certificate -FilePath `"c:\Temp\microburst.cer`" -CertStoreLocation `"Cert:\CurrentUser\My`" | Out-Null" | Out-File -FilePath "$pwd\$jobName.ps1" -Append
@@ -646,6 +647,7 @@ Function Get-AzPasswords
                         "`$password = `$myCredential.GetNetworkCredential().Password" | Out-File -FilePath "$pwd\$jobName2.ps1" -Append
 
                         # Copy the B64 encryption cert to the Automation Account host
+                        "New-Item -ItemType Directory -Force -Path `"C:\Temp`" | Out-Null" | Out-File -FilePath "$pwd\$jobName2.ps1" -Append
                         "`$FileName = `"C:\Temp\microburst.cer`"" | Out-File -FilePath "$pwd\$jobName2.ps1" -Append
                         "[IO.File]::WriteAllBytes(`$FileName, [Convert]::FromBase64String(`"$ENCbase64string`"))" | Out-File -FilePath "$pwd\$jobName2.ps1" -Append
                         "Import-Certificate -FilePath `"c:\Temp\microburst.cer`" -CertStoreLocation `"Cert:\CurrentUser\My`" | Out-Null" | Out-File -FilePath "$pwd\$jobName2.ps1" -Append
@@ -672,7 +674,8 @@ Function Get-AzPasswords
                     $dumpMI = $true
                     $dumpMiJobName = -join ((65..90) + (97..122) | Get-Random -Count 15 | % {[char]$_})
                     # Copy the B64 encryption cert to the Automation Account host
-                    "`$FileName = `"C:\Temp\microburst.cer`"" | Out-File -FilePath "$pwd\$dumpMiJobName.ps1"
+                    "New-Item -ItemType Directory -Force -Path `"C:\Temp`" | Out-Null" | Out-File -FilePath "$pwd\$dumpMiJobName.ps1"
+                    "`$FileName = `"C:\Temp\microburst.cer`"" | Out-File -Append -FilePath "$pwd\$dumpMiJobName.ps1"
                     "[IO.File]::WriteAllBytes(`$FileName, [Convert]::FromBase64String(`"$ENCbase64string`"))" | Out-File -FilePath "$pwd\$dumpMiJobName.ps1" -Append
                     "Import-Certificate -FilePath `"c:\Temp\microburst.cer`" -CertStoreLocation `"Cert:\CurrentUser\My`" | Out-Null" | Out-File -FilePath "$pwd\$dumpMiJobName.ps1" -Append
                     #Request a token from the IMDS

--- a/Az/Get-AzPasswords.ps1
+++ b/Az/Get-AzPasswords.ps1
@@ -168,7 +168,7 @@ Function Get-AzPasswords
         # List subscriptions, pipe out to gridview selection
         $Subscriptions = Get-AzSubscription -WarningAction SilentlyContinue
         $subChoice = $Subscriptions | out-gridview -Title "Select One or More Subscriptions" -PassThru
-        foreach ($sub in $subChoice) {Get-AzPasswords -Subscription $sub -ExportCerts $ExportCerts -FunctionApps $FunctionApps -ExportKube $ExportKube -Keys $Keys -AppServices $AppServices -AutomationAccounts $AutomationAccounts -CertificatePassword $CertificatePassword -ACR $ACR -StorageAccounts $StorageAccounts -ModifyPolicies $ModifyPolicies -CosmosDB $CosmosDB -AKS $AKS -ContainerApps $ContainerApps -APIManagement $APIManagement -ServiceBus $ServiceBus -AppConfiguration $AppConfiguration -BatchAccounts $BatchAccounts}
+        foreach ($sub in $subChoice) {Get-AzPasswords -Subscription $sub -ExportCerts $ExportCerts -FunctionApps $FunctionApps -ExportKube $ExportKube -Keys $Keys -AppServices $AppServices -AutomationAccounts $AutomationAccounts -CertificatePassword $CertificatePassword -ACR $ACR -StorageAccounts $StorageAccounts -ModifyPolicies $ModifyPolicies -CosmosDB $CosmosDB -AKS $AKS -ContainerApps $ContainerApps -APIManagement $APIManagement -ServiceBus $ServiceBus -AppConfiguration $AppConfiguration -BatchAccounts $BatchAccounts -TestPane $TestPane}
         break
     }
 

--- a/Az/Get-AzPasswords.ps1
+++ b/Az/Get-AzPasswords.ps1
@@ -831,6 +831,9 @@ Function Get-AzPasswords
                                 
                                             # Might be able to delete this line...
                                             if($jobOutput[0] -like "Credentials asset not found*"){$jobOutput[0] = "Not Created"; $jobOutput[1] = "Not Created"}
+
+                                            # Select only lines containing the protected content (skip eventual debug output)
+                                            $jobOutput = $jobOutput | Where-Object { $_.value -match "-----BEGIN CMS-----" }
         
                                             # Decrypt the output and add it to the table
                                             $cred1 = ($jobOutput[0].value | Unprotect-CmsMessage)


### PR DESCRIPTION
Here are a couple of fixes, described below and separated in distinct commits.

- it seems that the `C:\Temp` folder isn't always pre-created, making the function fails with this error:
![image](https://github.com/NetSPI/MicroBurst/assets/550823/e011c27c-b7c4-4507-b575-0fee50a9aee9)
-> fixed by force-creating it

- then I noticed this error:
![image](https://github.com/NetSPI/MicroBurst/assets/550823/58b9bb6e-0cc3-421b-bef0-4226c504f910)
After some debugging, I identified that it tried to call Unprotect-CmsMessage on these two output lines which aren't the ones we want (which are just below):
![image](https://github.com/NetSPI/MicroBurst/assets/550823/6577cbb2-607e-45a3-957e-a54fe5dfa57d)
-> I've added a filter to only select those interesting lines. It works much better :) (sorry for the heavy redacting but it's mandatory with this non-test env, trust me these values are correct!):
![image](https://github.com/NetSPI/MicroBurst/assets/550823/c750c38d-7a2a-48a6-a81d-80c9088e54fc)


- same issue when `-TestPane Y` is used:
![image](https://github.com/NetSPI/MicroBurst/assets/550823/0d8fe691-e7dd-4157-b0e9-c73a3b967170)
-> same solution
![image](https://github.com/NetSPI/MicroBurst/assets/550823/ede023db-d425-47a3-924f-01fdc312cd05)


- btw, while working with this `-TestPane` option, I noticed its value was lost at the beginning of the script so I fixed this too


I got a quick look at its `Get-AzurePasswords` brother, and it doesn't seem to suffer from the same issues since it's more basic.