### PR TITLE
Use -AsSecureString for new Az PS modules

### DIFF
--- a/Az/Get-AzAutomationConnectionScope.ps1
+++ b/Az/Get-AzAutomationConnectionScope.ps1
@@ -145,7 +145,7 @@ Function Get-AzAutomationConnectionScope{
         # Get Managed Identities (System-Assigned or User-Assigned)
         Write-Verbose "`t`tGetting list of Managed Identities"
         # Get a management API token and check the APIs for any usage of Managed Identities
-        $mgmtToken = (Get-AzAccessToken -ResourceUrl "https://management.azure.com").Token
+        $mgmtToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -ResourceUrl "https://management.azure.com" -AsSecureString).token)).GetNetworkCredential().Password
         $accountDetails = (Invoke-WebRequest -Verbose:$false -Uri (-join ("https://management.azure.com/subscriptions/", $_.SubscriptionId, "/resourceGroups/", $_.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $_.AutomationAccountName, "?api-version=2015-10-31")) -Headers @{Authorization="Bearer $mgmtToken"}).Content | ConvertFrom-Json
 
         $subID = $_.SubscriptionId

--- a/Az/Get-AzBatchAccountData.ps1
+++ b/Az/Get-AzBatchAccountData.ps1
@@ -177,7 +177,7 @@ function Get-AzBatchAccountData{
         }
         
         # Get all the extra Sub-Tasks
-        $batchToken = (Get-AzAccessToken -ResourceUrl "https://batch.core.windows.net/").Token
+        $batchToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -ResourceUrl "https://batch.core.windows.net/" -AsSecureString).token)).GetNetworkCredential().Password
         $jobsList = ((Invoke-WebRequest -Verbose:$false -Uri "https://$($batchContext.AccountEndpoint)/jobs?api-version=2022-10-01.16.0&maxresults=1000&paginationeffort=1" -Headers @{Authorization="Bearer $batchToken"}).Content | ConvertFrom-Json).value
         $jobsList | ForEach-Object{
             $currentJob = $_.id

--- a/Az/Get-AzMachineLearningCredentials.ps1
+++ b/Az/Get-AzMachineLearningCredentials.ps1
@@ -93,7 +93,7 @@ Function Get-AzMachineLearningCredentials
     # Find All the AML Resources
     $workspaces = Get-AzResource -ResourceType Microsoft.MachineLearningServices/workspaces
     
-    $token = (Get-AzAccessToken).Token
+    $token = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
 
     $workspaces | ForEach-Object{
         

--- a/Az/Get-AzMachineLearningData.ps1
+++ b/Az/Get-AzMachineLearningData.ps1
@@ -231,7 +231,7 @@ function Get-AzMachineLearningData {
         $url = "https://management.azure.com/subscriptions/$Subscription/resourceGroups/$ResourceGroupName/providers/Microsoft.MachineLearningServices/workspaces/$currentWorkspace/connections?api-version=2023-08-01-preview"
 
         try {
-            $accessToken = (Get-AzAccessToken -ResourceUrl "https://management.azure.com").Token
+            $accessToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -ResourceUrl "https://management.azure.com" -AsSecureString).token)).GetNetworkCredential().Password
             if (-not $accessToken) {
                 Write-Error "Unable to retrieve the access token. Make sure you are logged in using Az PowerShell."
                 exit 1

--- a/Az/Get-AzPasswords.ps1
+++ b/Az/Get-AzPasswords.ps1
@@ -210,7 +210,7 @@ Function Get-AzPasswords
                 #$currentOID = ($LoginStatus.Account.ExtendedProperties.HomeAccountId).split('.')[0]
                 
                 # Borrowed from - https://www.michev.info/Blog/Post/2140/decode-jwt-access-and-id-tokens-via-powershell
-                $tokenPayload = ((Get-AzAccessToken).Token).Split(".")[1].Replace('-', '+').Replace('_', '/')
+                $tokenPayload = ((New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password).Split(".")[1].Replace('-', '+').Replace('_', '/')
                 #Fix padding as needed, keep adding "=" until string length modulus 4 reaches 0
                 while ($tokenPayload.Length % 4) { $tokenPayload += "=" }               
                 $currentOID = ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($tokenPayload)) | ConvertFrom-Json).oid
@@ -486,8 +486,8 @@ Function Get-AzPasswords
                             $spSecret = ($_.SiteConfig.AppSettings | where Name -EQ 'MICROSOFT_PROVIDER_AUTHENTICATION_SECRET').value
 
                             # Use APIs to grab Client ID
-                            $mgmtToken = (Get-AzAccessToken -ResourceUrl 'https://management.azure.com/').Token
-                            $subID = (get-azcontext).Subscription.Id
+                            $mgmtToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -ResourceUrl "https://management.azure.com/" -AsSecureString).token)).GetNetworkCredential().Password
+                            $subID = (Get-AzContext).Subscription.Id
                             $servicePrincipalID = ((Invoke-WebRequest -Uri (-join('https://management.azure.com/subscriptions/',$subID,'/resourceGroups/',$_.ResourceGroup,'/providers/Microsoft.Web/sites/',$_.Name,'/Config/authsettingsV2/list?api-version=2018-11-01')) -UseBasicParsing -Headers @{ Authorization ="Bearer $mgmtToken"} -Verbose:$false ).content | ConvertFrom-Json).properties.identityProviders.azureActiveDirectory.registration.clientId
 
                             $spClientID = ""
@@ -669,7 +669,7 @@ Function Get-AzPasswords
                 #Assume there's no MI
                 $dumpMI = $false
                 #Need to fetch via the REST endpoint to check if there's an identity
-                $mgmtToken = (Get-AzAccessToken -ResourceUrl "https://management.azure.com").Token
+                $mgmtToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -ResourceUrl "https://management.azure.com/" -AsSecureString).token)).GetNetworkCredential().Password
                 $accountDetails = (Invoke-WebRequest -Verbose:$false -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "?api-version=2015-10-31")) -Headers @{Authorization="Bearer $mgmtToken"}).Content | ConvertFrom-Json
                 if($accountDetails.identity.type -match "systemassigned"){
                 
@@ -716,7 +716,7 @@ Function Get-AzPasswords
                             try{
                                 if($TestPane -eq "Y"){
                                     #For test pane execution we need to avoid the call to Publish-AzAutomationRunbook since the runbook needs to be a draft
-                                    $mgmtToken = (Get-AzAccessToken).Token
+                                    $mgmtToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
                                     #Hit the /draft/testJob endpoint directly to create the job, poll for it to finish, and get the output
                                     $createJob = (Invoke-WebRequest -Verbose:$false -Method PUT -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $jobName,"/draft/testJob?api-version=2015-10-31")) -Headers @{Authorization="Bearer $mgmtToken"} -ContentType application/json -Body "{'runOn':''}").Content | ConvertFrom-Json
                                     $jobStatus = (Invoke-WebRequest -Verbose:$false -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $jobName,"/draft/testJob?api-version=2019-06-01")) -Headers @{Authorization="Bearer $mgmtToken"}).Content | ConvertFrom-Json
@@ -799,7 +799,7 @@ Function Get-AzPasswords
 
                                 try{
                                     if($TestPane -eq "Y"){
-                                        $mgmtToken = (Get-AzAccessToken).Token
+                                        $mgmtToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
                                         $createJob = (Invoke-WebRequest -Verbose:$false -Method PUT -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $jobToRun,"/draft/testJob?api-version=2015-10-31")) -Headers @{Authorization="Bearer $mgmtToken"} -ContentType application/json -Body "{'runOn':''}").Content | ConvertFrom-Json
                                         $jobStatus = (Invoke-WebRequest -Verbose:$false -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $jobToRun,"/draft/testJob?api-version=2019-06-01")) -Headers @{Authorization="Bearer $mgmtToken"}).Content | ConvertFrom-Json
                                         while($jobStatus.Status -ne "Completed"){
@@ -868,7 +868,7 @@ Function Get-AzPasswords
                     
                         try{
                             if($TestPane -eq "Y"){
-                                $mgmtToken = (Get-AzAccessToken).Token
+                                $mgmtToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
                                 $createJob = (Invoke-WebRequest -Verbose:$false -Method PUT -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $dumpMiJobName,"/draft/testJob?api-version=2015-10-31")) -Headers @{Authorization="Bearer $mgmtToken"} -ContentType application/json -Body "{'runOn':''}").Content | ConvertFrom-Json
                                 $jobStatus = (Invoke-WebRequest -Verbose:$false -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $dumpMiJobName,"/draft/testJob?api-version=2019-06-01")) -Headers @{Authorization="Bearer $mgmtToken"}).Content | ConvertFrom-Json
                                 while($jobStatus.Status -ne "Completed"){
@@ -959,7 +959,7 @@ Function Get-AzPasswords
         $clusters = Get-AzAksCluster
 
         # Get a token for the API
-        $bearerToken = (Get-AzAccessToken).Token
+        $bearerToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
 
         $clusters | ForEach-Object{
             $clusterID = $_.Id
@@ -1080,7 +1080,7 @@ Function Get-AzPasswords
                     $appSettings = ($_.ApplicationSettings.MICROSOFT_PROVIDER_AUTHENTICATION_SECRET)
 
                     # Use APIs to grab Client ID
-                    $mgmtToken = (Get-AzAccessToken -ResourceUrl 'https://management.azure.com/').Token
+                    $mgmtToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -ResourceUrl "https://management.azure.com/" -AsSecureString).token)).GetNetworkCredential().Password
                     $subID = (get-azcontext).Subscription.Id
                     $servicePrincipalID = ((Invoke-WebRequest -Uri (-join('https://management.azure.com/subscriptions/',$subID,'/resourceGroups/',$_.ResourceGroup,'/providers/Microsoft.Web/sites/',$_.Name,'/Config/authsettingsV2/list?api-version=2018-11-01')) -UseBasicParsing -Headers @{ Authorization ="Bearer $mgmtToken"} -Verbose:$false ).content | ConvertFrom-Json).properties.identityProviders.azureActiveDirectory.registration.clientId
 
@@ -1107,7 +1107,7 @@ Function Get-AzPasswords
         # Container Apps Section
 
         # Variable Set Up
-        $CAmanagementToken = (Get-AzAccessToken).Token
+        $CAmanagementToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
         $subID = (Get-AzContext).Subscription.Id
 
         # List Resource Groups

--- a/Az/Invoke-AzACRTokenGenerator.ps1
+++ b/Az/Invoke-AzACRTokenGenerator.ps1
@@ -99,7 +99,7 @@ Function Invoke-AzACRTokenGenerator
         $TempTblTokens.Columns.Add("Token") | Out-Null
 
         # Get Token for REST APIs
-        $basetoken = (Get-AzAccessToken).Token
+        $basetoken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
 
         # Iterate through the ACRs
         $acrChoice | ForEach-Object{
@@ -184,7 +184,7 @@ Function Invoke-AzACRTokenTask
     )
 
     # Get Token for REST APIs
-    $basetoken = (Get-AzAccessToken).Token
+    $basetoken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
 
     # Set Random names for the tasks. Prevents conflict issues
     $taskName = -join ((65..90) + (97..122) | Get-Random -Count 15 | % {[char]$_})

--- a/Az/Invoke-AzUADeploymentScript.ps1
+++ b/Az/Invoke-AzUADeploymentScript.ps1
@@ -61,7 +61,7 @@ Function Invoke-AzUADeploymentScript
 
         [Parameter(Mandatory=$false,
         HelpMessage="Command to run in the deployment script.")]
-        [string]$Command = "(Get-AzAccessToken -ResourceUrl $TokenScope).Token"
+        [string]$Command = "(New-Object System.Management.Automation.PSCredential('token', (Get-AzAccessToken -ResourceUrl $TokenScope -AsSecureString).token)).GetNetworkCredential().Password"
     )
 
     # Check to see if we're logged in
@@ -109,7 +109,7 @@ Function Invoke-AzUADeploymentScript
         $uamidID = $_.PrincipalId
         $uamidName = $_.Name
         $uamidSub = $_.Id.Split('/')[2]
-        $token = (Get-AzAccessToken).Token        
+        $token = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
 
         Write-Verbose "`t`tChecking permissions on $($_.Name) Managed Identity"
 
@@ -187,7 +187,7 @@ Function Invoke-AzUADeploymentScript
             },
             `"command`": {
                 `"type`": `"String`",
-			    `"defaultValue`":`"(Get-AzAccessToken).Token`"
+			    `"defaultValue`":`"(New-Object System.Management.Automation.PSCredential('token', (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password`"
             }		
         },
         `"variables`": {},

--- a/Misc/Get-AzAppRegistrationManifest.ps1
+++ b/Misc/Get-AzAppRegistrationManifest.ps1
@@ -19,7 +19,7 @@ Function Get-AzAppRegistrationManifest
     Param()
 
     $resource = "https://graph.microsoft.com"
-    $accessToken = (Get-AzAccessToken -ResourceUrl $resource).Token
+    $accessToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -ResourceUrl $resource -AsSecureString).token)).GetNetworkCredential().Password
     $url = "https://graph.microsoft.com/v1.0/myorganization/applications/?`$select=displayName,id,appId,createdDateTime,keyCredentials"
 
     $authHeader = @{

--- a/REST/Get-AzRestBastionShareableLink.ps1
+++ b/REST/Get-AzRestBastionShareableLink.ps1
@@ -5,8 +5,8 @@ function Get-AzRestBastionShareableLink {
     # https://learn.microsoft.com/en-us/azure/bastion/shareable-link
 
 
-    $Token = Get-AzAccessToken
-    $Headers = @{Authorization = "Bearer $($Token.Token)" }
+    $Token = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
+    $Headers = @{Authorization = "Bearer $Token)" }
 
     $AzBastions = Get-AzBastion
     Write-Output "Getting all Shareable Links for Azure bastions"

--- a/REST/Invoke-AzElevatedAccessToggle.ps1
+++ b/REST/Invoke-AzElevatedAccessToggle.ps1
@@ -7,8 +7,8 @@ Function Invoke-AzElevatedAccessToggle {
 
     try {
 
-        $Token = Get-AzAccessToken
-        $Headers = @{Authorization = "Bearer $($Token.Token)" }
+        $Token = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
+        $Headers = @{Authorization = "Bearer $Token" }
         $ElevatedAccessToggle = Invoke-RestMethod -Method POST -Uri "https://management.azure.com/providers/Microsoft.Authorization/elevateAccess?api-version=2016-07-01" -Headers $Headers
 
         $ElevatedAccessToggle

--- a/REST/Invoke-AzRESTBastionShareableLink.ps1
+++ b/REST/Invoke-AzRESTBastionShareableLink.ps1
@@ -13,8 +13,8 @@ function Invoke-AzRestBastionShareableLink {
     [string]$VMName = ""
     )
 
-    $Token = Get-AzAccessToken
-    $Headers = @{Authorization = "Bearer $($Token.Token)" }
+    $Token = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
+    $Headers = @{Authorization = "Bearer $Token" }
 
     $AzBastions = Get-AzBastion
     Write-Output "Enabling Shareable Link feature on all Azure bastions"

--- a/REST/Invoke-AzVMCommandREST.ps1
+++ b/REST/Invoke-AzVMCommandREST.ps1
@@ -32,7 +32,7 @@ function Invoke-AzVMCommandREST{
 
     if($managementToken -eq ""){
         Write-Output "No token provided, attempting to use Az PowerShell context"
-        $managementToken = (Get-AzAccessToken).Token
+        $managementToken = (New-Object System.Management.Automation.PSCredential("token", (Get-AzAccessToken -AsSecureString).token)).GetNetworkCredential().Password
         
         if($managementToken -eq $null){
             Write-Output "Unable to use Az PowerShell module for a token, attempting IMDS token"


### PR DESCRIPTION
Get-AzAccessToken will require the use of -AsSecureString in new releases. This PR addresses all uses of Get-AzAccessToken with the exception of PowerUpSql.psm1 which needs more than the token value. That will still need to be addresses, and I'll investigate in a different commit / PR.

All commands to request the token have been validated that a valid token is output, but I did not perform complete testing of the various functions themselves. I will see if I have time to do that tonight, but in the meantime, this might be helpful for those that want to validate prior to merge ;)

This addresses issue #46 