### PR TITLE
Handle tokens using SecureString

### DIFF
--- a/Az/Get-AzAutomationConnectionScope.ps1
+++ b/Az/Get-AzAutomationConnectionScope.ps1
@@ -145,7 +145,18 @@ Function Get-AzAutomationConnectionScope{
         # Get Managed Identities (System-Assigned or User-Assigned)
         Write-Verbose "`t`tGetting list of Managed Identities"
         # Get a management API token and check the APIs for any usage of Managed Identities
-        $mgmtToken = (Get-AzAccessToken -ResourceUrl "https://management.azure.com").Token
+        $AccessToken = Get-AzAccessToken -ResourceUrl "https://management.azure.com/"
+        if ($AccessToken.Token -is [System.Security.SecureString]) {
+            $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+            try {
+                $mgmtToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+            } finally {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+            }
+        } else {
+            $mgmtToken = $AccessToken.Token
+        }
+
         $accountDetails = (Invoke-WebRequest -Verbose:$false -Uri (-join ("https://management.azure.com/subscriptions/", $_.SubscriptionId, "/resourceGroups/", $_.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $_.AutomationAccountName, "?api-version=2015-10-31")) -Headers @{Authorization="Bearer $mgmtToken"}).Content | ConvertFrom-Json
 
         $subID = $_.SubscriptionId

--- a/Az/Get-AzMachineLearningCredentials.ps1
+++ b/Az/Get-AzMachineLearningCredentials.ps1
@@ -93,7 +93,17 @@ Function Get-AzMachineLearningCredentials
     # Find All the AML Resources
     $workspaces = Get-AzResource -ResourceType Microsoft.MachineLearningServices/workspaces
     
-    $token = (Get-AzAccessToken).Token
+    $AccessToken = Get-AzAccessToken
+    if ($AccessToken.Token -is [System.Security.SecureString]) {
+        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+        try {
+            $Token = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+        } finally {
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+        }
+    } else {
+        $Token = $AccessToken.Token
+    }
 
     $workspaces | ForEach-Object{
         

--- a/Az/Get-AzPasswords.ps1
+++ b/Az/Get-AzPasswords.ps1
@@ -210,7 +210,18 @@ Function Get-AzPasswords
                 #$currentOID = ($LoginStatus.Account.ExtendedProperties.HomeAccountId).split('.')[0]
                 
                 # Borrowed from - https://www.michev.info/Blog/Post/2140/decode-jwt-access-and-id-tokens-via-powershell
-                $tokenPayload = ((Get-AzAccessToken).Token).Split(".")[1].Replace('-', '+').Replace('_', '/')
+                $AccessToken = Get-AzAccessToken
+                if ($AccessToken.Token -is [System.Security.SecureString]) {
+                    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+                    try {
+                        $Token = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+                    } finally {
+                        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+                    }
+                } else {
+                    $Token = $AccessToken.Token
+                }
+                $tokenPayload = ($Token.Split(".")[1].Replace('-', '+').Replace('_', '/')
                 #Fix padding as needed, keep adding "=" until string length modulus 4 reaches 0
                 while ($tokenPayload.Length % 4) { $tokenPayload += "=" }               
                 $currentOID = ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($tokenPayload)) | ConvertFrom-Json).oid
@@ -486,7 +497,17 @@ Function Get-AzPasswords
                             $spSecret = ($_.SiteConfig.AppSettings | where Name -EQ 'MICROSOFT_PROVIDER_AUTHENTICATION_SECRET').value
 
                             # Use APIs to grab Client ID
-                            $mgmtToken = (Get-AzAccessToken -ResourceUrl 'https://management.azure.com/').Token
+                            $AccessToken = Get-AzAccessToken -ResourceUrl "https://management.azure.com/"
+                            if ($AccessToken.Token -is [System.Security.SecureString]) {
+                                $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+                                try {
+                                    $mgmtToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+                                } finally {
+                                    [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+                                }
+                            } else {
+                                $mgmtToken = $AccessToken.Token
+                            }
                             $subID = (get-azcontext).Subscription.Id
                             $servicePrincipalID = ((Invoke-WebRequest -Uri (-join('https://management.azure.com/subscriptions/',$subID,'/resourceGroups/',$_.ResourceGroup,'/providers/Microsoft.Web/sites/',$_.Name,'/Config/authsettingsV2/list?api-version=2018-11-01')) -UseBasicParsing -Headers @{ Authorization ="Bearer $mgmtToken"} -Verbose:$false ).content | ConvertFrom-Json).properties.identityProviders.azureActiveDirectory.registration.clientId
 
@@ -669,7 +690,17 @@ Function Get-AzPasswords
                 #Assume there's no MI
                 $dumpMI = $false
                 #Need to fetch via the REST endpoint to check if there's an identity
-                $mgmtToken = (Get-AzAccessToken -ResourceUrl "https://management.azure.com").Token
+                $AccessToken = Get-AzAccessToken -ResourceUrl "https://management.azure.com/"
+                if ($AccessToken.Token -is [System.Security.SecureString]) {
+                    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+                    try {
+                        $mgmtToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+                    } finally {
+                        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+                    }
+                } else {
+                    $mgmtToken = $AccessToken.Token
+                }
                 $accountDetails = (Invoke-WebRequest -Verbose:$false -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "?api-version=2015-10-31")) -Headers @{Authorization="Bearer $mgmtToken"}).Content | ConvertFrom-Json
                 if($accountDetails.identity.type -match "systemassigned"){
                 
@@ -716,7 +747,17 @@ Function Get-AzPasswords
                             try{
                                 if($TestPane -eq "Y"){
                                     #For test pane execution we need to avoid the call to Publish-AzAutomationRunbook since the runbook needs to be a draft
-                                    $mgmtToken = (Get-AzAccessToken).Token
+                                    $AccessToken = Get-AzAccessToken
+                                    if ($AccessToken.Token -is [System.Security.SecureString]) {
+                                        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+                                        try {
+                                            $mgmtToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+                                        } finally {
+                                            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+                                        }
+                                    } else {
+                                        $mgmtToken = $AccessToken.Token
+                                    }
                                     #Hit the /draft/testJob endpoint directly to create the job, poll for it to finish, and get the output
                                     $createJob = (Invoke-WebRequest -Verbose:$false -Method PUT -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $jobName,"/draft/testJob?api-version=2015-10-31")) -Headers @{Authorization="Bearer $mgmtToken"} -ContentType application/json -Body "{'runOn':''}").Content | ConvertFrom-Json
                                     $jobStatus = (Invoke-WebRequest -Verbose:$false -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $jobName,"/draft/testJob?api-version=2019-06-01")) -Headers @{Authorization="Bearer $mgmtToken"}).Content | ConvertFrom-Json
@@ -799,7 +840,17 @@ Function Get-AzPasswords
 
                                 try{
                                     if($TestPane -eq "Y"){
-                                        $mgmtToken = (Get-AzAccessToken).Token
+                                        $AccessToken = Get-AzAccessToken
+                                        if ($AccessToken.Token -is [System.Security.SecureString]) {
+                                            $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+                                            try {
+                                                $mgmtToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+                                            } finally {
+                                                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+                                            }
+                                        } else {
+                                            $mgmtToken = $AccessToken.Token
+                                        }
                                         $createJob = (Invoke-WebRequest -Verbose:$false -Method PUT -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $jobToRun,"/draft/testJob?api-version=2015-10-31")) -Headers @{Authorization="Bearer $mgmtToken"} -ContentType application/json -Body "{'runOn':''}").Content | ConvertFrom-Json
                                         $jobStatus = (Invoke-WebRequest -Verbose:$false -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $jobToRun,"/draft/testJob?api-version=2019-06-01")) -Headers @{Authorization="Bearer $mgmtToken"}).Content | ConvertFrom-Json
                                         while($jobStatus.Status -ne "Completed"){
@@ -868,7 +919,17 @@ Function Get-AzPasswords
                     
                         try{
                             if($TestPane -eq "Y"){
-                                $mgmtToken = (Get-AzAccessToken).Token
+                                $AccessToken = Get-AzAccessToken
+                                if ($AccessToken.Token -is [System.Security.SecureString]) {
+                                    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+                                    try {
+                                        $mgmtToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+                                    } finally {
+                                        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+                                    }
+                                } else {
+                                    $mgmtToken = $AccessToken.Token
+                                }
                                 $createJob = (Invoke-WebRequest -Verbose:$false -Method PUT -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $dumpMiJobName,"/draft/testJob?api-version=2015-10-31")) -Headers @{Authorization="Bearer $mgmtToken"} -ContentType application/json -Body "{'runOn':''}").Content | ConvertFrom-Json
                                 $jobStatus = (Invoke-WebRequest -Verbose:$false -Uri (-join ("https://management.azure.com/subscriptions/", $AutoAccount.SubscriptionId, "/resourceGroups/", $AutoAccount.ResourceGroupName, "/providers/Microsoft.Automation/automationAccounts/", $AutoAccount.AutomationAccountName, "/runbooks/", $dumpMiJobName,"/draft/testJob?api-version=2019-06-01")) -Headers @{Authorization="Bearer $mgmtToken"}).Content | ConvertFrom-Json
                                 while($jobStatus.Status -ne "Completed"){
@@ -959,7 +1020,17 @@ Function Get-AzPasswords
         $clusters = Get-AzAksCluster
 
         # Get a token for the API
-        $bearerToken = (Get-AzAccessToken).Token
+        $AccessToken = Get-AzAccessToken
+        if ($AccessToken.Token -is [System.Security.SecureString]) {
+            $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+            try {
+                $bearerToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+            } finally {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+            }
+        } else {
+            $bearerToken = $AccessToken.Token
+        }
 
         $clusters | ForEach-Object{
             $clusterID = $_.Id
@@ -1080,7 +1151,17 @@ Function Get-AzPasswords
                     $appSettings = ($_.ApplicationSettings.MICROSOFT_PROVIDER_AUTHENTICATION_SECRET)
 
                     # Use APIs to grab Client ID
-                    $mgmtToken = (Get-AzAccessToken -ResourceUrl 'https://management.azure.com/').Token
+                    $AccessToken = Get-AzAccessToken -ResourceUrl "https://management.azure.com/"
+                    if ($AccessToken.Token -is [System.Security.SecureString]) {
+                        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+                        try {
+                            $mgmtToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+                        } finally {
+                            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+                        }
+                    } else {
+                        $mgmtToken = $AccessToken.Token
+                    }
                     $subID = (get-azcontext).Subscription.Id
                     $servicePrincipalID = ((Invoke-WebRequest -Uri (-join('https://management.azure.com/subscriptions/',$subID,'/resourceGroups/',$_.ResourceGroup,'/providers/Microsoft.Web/sites/',$_.Name,'/Config/authsettingsV2/list?api-version=2018-11-01')) -UseBasicParsing -Headers @{ Authorization ="Bearer $mgmtToken"} -Verbose:$false ).content | ConvertFrom-Json).properties.identityProviders.azureActiveDirectory.registration.clientId
 
@@ -1107,7 +1188,17 @@ Function Get-AzPasswords
         # Container Apps Section
 
         # Variable Set Up
-        $CAmanagementToken = (Get-AzAccessToken).Token
+        $AccessToken = Get-AzAccessToken
+        if ($AccessToken.Token -is [System.Security.SecureString]) {
+            $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+            try {
+                $CAmanagementToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+            } finally {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+            }
+        } else {
+            $CAmanagementToken = $AccessToken.Token
+        }
         $subID = (Get-AzContext).Subscription.Id
 
         # List Resource Groups

--- a/Az/Invoke-AzACRTokenGenerator.ps1
+++ b/Az/Invoke-AzACRTokenGenerator.ps1
@@ -99,7 +99,17 @@ Function Invoke-AzACRTokenGenerator
         $TempTblTokens.Columns.Add("Token") | Out-Null
 
         # Get Token for REST APIs
-        $basetoken = (Get-AzAccessToken).Token
+        $AccessToken = Get-AzAccessToken
+        if ($AccessToken.Token -is [System.Security.SecureString]) {
+            $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+            try {
+                $basetoken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+            } finally {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+            }
+        } else {
+            $basetoken = $AccessToken.Token
+        }
 
         # Iterate through the ACRs
         $acrChoice | ForEach-Object{
@@ -184,7 +194,17 @@ Function Invoke-AzACRTokenTask
     )
 
     # Get Token for REST APIs
-    $basetoken = (Get-AzAccessToken).Token
+    $AccessToken = Get-AzAccessToken
+    if ($AccessToken.Token -is [System.Security.SecureString]) {
+        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+        try {
+            $basetoken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+        } finally {
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+        }
+    } else {
+        $basetoken = $AccessToken.Token
+    }
 
     # Set Random names for the tasks. Prevents conflict issues
     $taskName = -join ((65..90) + (97..122) | Get-Random -Count 15 | % {[char]$_})

--- a/Az/Invoke-AzUADeploymentScript.ps1
+++ b/Az/Invoke-AzUADeploymentScript.ps1
@@ -109,7 +109,17 @@ Function Invoke-AzUADeploymentScript
         $uamidID = $_.PrincipalId
         $uamidName = $_.Name
         $uamidSub = $_.Id.Split('/')[2]
-        $token = (Get-AzAccessToken).Token        
+        $AccessToken = Get-AzAccessToken
+        if ($AccessToken.Token -is [System.Security.SecureString]) {
+            $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+            try {
+                $Token = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+            } finally {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+            }
+        } else {
+            $Token = $AccessToken.Token
+        }
 
         Write-Verbose "`t`tChecking permissions on $($_.Name) Managed Identity"
 

--- a/Misc/Get-AzAppRegistrationManifest.ps1
+++ b/Misc/Get-AzAppRegistrationManifest.ps1
@@ -19,11 +19,21 @@ Function Get-AzAppRegistrationManifest
     Param()
 
     $resource = "https://graph.microsoft.com"
-    $accessToken = (Get-AzAccessToken -ResourceUrl $resource).Token
+    $AccessToken = Get-AzAccessToken -ResourceUrl $resource
+    if ($AccessToken.Token -is [System.Security.SecureString]) {
+        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+        try {
+            $Token = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+        } finally {
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+        }
+    } else {
+        $Token = $AccessToken.Token
+    }
     $url = "https://graph.microsoft.com/v1.0/myorganization/applications/?`$select=displayName,id,appId,createdDateTime,keyCredentials"
 
     $authHeader = @{
-      "Authorization" = "Bearer " + $accessToken
+      "Authorization" = "Bearer " + $Token
     }
 
     while ($null -ne $url) {

--- a/REST/Get-AzRestBastionShareableLink.ps1
+++ b/REST/Get-AzRestBastionShareableLink.ps1
@@ -5,8 +5,18 @@ function Get-AzRestBastionShareableLink {
     # https://learn.microsoft.com/en-us/azure/bastion/shareable-link
 
 
-    $Token = Get-AzAccessToken
-    $Headers = @{Authorization = "Bearer $($Token.Token)" }
+    $AccessToken = Get-AzAccessToken
+    if ($AccessToken.Token -is [System.Security.SecureString]) {
+        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+        try {
+            $Token = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+        } finally {
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+        }
+    } else {
+        $Token = $AccessToken.Token
+    }
+    $Headers = @{Authorization = "Bearer $Token" }
 
     $AzBastions = Get-AzBastion
     Write-Output "Getting all Shareable Links for Azure bastions"

--- a/REST/Invoke-AzElevatedAccessToggle.ps1
+++ b/REST/Invoke-AzElevatedAccessToggle.ps1
@@ -7,8 +7,18 @@ Function Invoke-AzElevatedAccessToggle {
 
     try {
 
-        $Token = Get-AzAccessToken
-        $Headers = @{Authorization = "Bearer $($Token.Token)" }
+        $AccessToken = Get-AzAccessToken
+        if ($AccessToken.Token -is [System.Security.SecureString]) {
+            $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+            try {
+                $Token = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+            } finally {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+            }
+        } else {
+            $Token = $AccessToken.Token
+        }
+        $Headers = @{Authorization = "Bearer $Token" }
         $ElevatedAccessToggle = Invoke-RestMethod -Method POST -Uri "https://management.azure.com/providers/Microsoft.Authorization/elevateAccess?api-version=2016-07-01" -Headers $Headers
 
         $ElevatedAccessToggle

--- a/REST/Invoke-AzRESTBastionShareableLink.ps1
+++ b/REST/Invoke-AzRESTBastionShareableLink.ps1
@@ -13,8 +13,18 @@ function Invoke-AzRestBastionShareableLink {
     [string]$VMName = ""
     )
 
-    $Token = Get-AzAccessToken
-    $Headers = @{Authorization = "Bearer $($Token.Token)" }
+    $AccessToken = Get-AzAccessToken
+    if ($AccessToken.Token -is [System.Security.SecureString]) {
+        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+        try {
+            $Token = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+        } finally {
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+        }
+    } else {
+        $Token = $AccessToken.Token
+    }
+    $Headers = @{Authorization = "Bearer $Token" }
 
     $AzBastions = Get-AzBastion
     Write-Output "Enabling Shareable Link feature on all Azure bastions"

--- a/REST/Invoke-AzVMCommandREST.ps1
+++ b/REST/Invoke-AzVMCommandREST.ps1
@@ -32,7 +32,17 @@ function Invoke-AzVMCommandREST{
 
     if($managementToken -eq ""){
         Write-Output "No token provided, attempting to use Az PowerShell context"
-        $managementToken = (Get-AzAccessToken).Token
+        $AccessToken = Get-AzAccessToken
+        if ($AccessToken.Token -is [System.Security.SecureString]) {
+            $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AccessToken.Token)
+            try {
+                $managementToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+            } finally {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+            }
+        } else {
+            $managementToken = $AccessToken.Token
+        }
         
         if($managementToken -eq $null){
             Write-Output "Unable to use Az PowerShell module for a token, attempting IMDS token"


### PR DESCRIPTION
This addresses issue #46 with the exception of two uses of Get-AzAccessToken in the templates in Invoke-AzuUADeploymentScript.ps1.

Some of the Az modules have a function called Unprotect-SecureString.ps1 that is used for this function. Rather than attempting to have scripts call out to that function (unsure of impact if run from Function apps or similar), I felt it was safer to directly add that code into each use of Get-AzAccessToken.

The only other thing of note is that I was able to touch up PowerUpSQL.psm1 by getting the token value, then rebuilding the access token to pass through as a JSON payload in the body.