### PR TITLE
Improved Domain Info Scripts: Now with RBAC Details and Error Fix

### DIFF
--- a/Az/Get-AzDomainInfo.ps1
+++ b/Az/Get-AzDomainInfo.ps1
@@ -256,7 +256,11 @@ Function Get-AzDomainInfo
 
                             # URL for listing publicly available files
                             $uriList = "https://"+(-join ($StorageAccountName,'.blob.core.windows.net/',$_.Name))+"/?restype=container&comp=list"
-                            $FileList = (Invoke-WebRequest -uri $uriList -Method Get -Verbose:$False).Content
+                            try {
+                                $FileList = (Invoke-WebRequest -Uri $uriList -Method Get -Verbose:$False).Content
+                            } catch {
+                                # No Action
+                            }
                                 
                             # Microsoft includes these characters in the response, Thanks...
                             [xml]$xmlFileList = $FileList -replace 'ï»¿'


### PR DESCRIPTION
Hi,

I've added new fields to the scripts Get-AzDomainInfo.ps1 and Get-AzureADDomainInfo.ps1.

- In Get-AzDomainInfo.ps1, I've included RBAC assignments for users and groups, along with the corresponding resources. 

![Az_RBAC](https://github.com/user-attachments/assets/6b044ddc-f7eb-48cb-ad3e-51d86f46e688)

- In Get-AzureADDomainInfo.ps1, I've added two new columns to the AzureAD_Users file: Directory Role and Groups they belong to.

![AzureAD](https://github.com/user-attachments/assets/f6c55762-2d13-4795-bd2f-e751a80a2458)

I often need this information during penetration testing, so I implemented these features to streamline the process. I also fixed a small error that occurred when using Invoke-WebRequest to check if the blob is public accessible.

![error](https://github.com/user-attachments/assets/62e4597f-78db-45c3-9737-31b87fc6deb6)