### PR TITLE
Update Invoke-EnumerateAzureBlobs.ps1 to ensure UseBasicParsing on all Invoke-WebRequest calls

### DIFF
--- a/Misc/Invoke-EnumerateAzureBlobs.ps1
+++ b/Misc/Invoke-EnumerateAzureBlobs.ps1
@@ -203,7 +203,7 @@ $lookupResult = ""
                     Write-Host "Found Container - $dirGuess"
                     # URL for listing publicly available files
                     $uriList = "https://"+$dirGuess+"?restype=container&comp=list&include=versions"
-                    $FileList = (Invoke-WebRequest -uri $uriList -Headers @{"x-ms-version"="2019-12-12"} -Method Get).Content
+                    $FileList = (Invoke-WebRequest -uri $uriList -Headers @{"x-ms-version"="2019-12-12"} -Method Get -UseBasicParsing).Content
                     # Microsoft includes these characters in the response, Thanks...
                     [xml]$xmlFileList = $FileList -replace "ï»¿"
                     $foundURL = $xmlFileList.EnumerationResults.Blobs.Blob


### PR DESCRIPTION
Adds the `-UseBasicParsing` flag to the `Invoke-WebRequest` command for listing public files in an Azure Blob Storage container. 

The change prevents a silent error when Internet Explorer is not configured/available, which in turn prevents printing of any feedback on the files available in the container.
> `Invoke-WebRequest : The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.` 

This is the same issue that was corrected in https://github.com/NetSPI/MicroBurst/pull/14 for a different instance of `Invoke-WebRequest`. [This flag is deprecated in PowerShell 6 but is still available for backwards compatibility](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.5#-usebasicparsing). I was running the script from a box running PowerShell 5 and saw the issue, but if there is no desire to support PowerShell 5, feel free to disregard this PR. 