### PR TITLE
Correctly handle public Azure Blob Storage containers containing one file

### DIFF
--- a/Misc/Invoke-EnumerateAzureBlobs.ps1
+++ b/Misc/Invoke-EnumerateAzureBlobs.ps1
@@ -90,11 +90,12 @@ $lookupResult = ""
         $lookupResult = ""
     }
 
-    $linecount = Get-Content $Permutations | Measure-Object –Line | select Lines
+    $permutationsContent = Get-Content $Permutations | Where-Object {$_.trim() -ne "" }
+    $linecount = $permutationsContent | Measure-Object –Line | select Lines
     $iter = 0
 
     # Check Permutations
-    foreach($word in (Get-Content $Permutations)){
+    foreach($word in $permutationsContent){
         
         # Track the progress
         $iter++
@@ -167,22 +168,20 @@ $lookupResult = ""
         Write-Host ""
     }
 
+    # Read in file
+    $folderContent = Get-Content $Folders | Where-Object {$_.trim() -ne "" }
+
+    # Append any Bing results
+    if ($BingAPIKey){$folderContent += ($bingContainers | select -Unique)}
+
     # Get line counts for number of storage accounts for statusing
-    $foldercount = Get-Content $Folders | Measure-Object –Line | select Lines
-    if ($BingAPIKey){ $foldercount.Lines += (($bingContainers | select -Unique).count)}
+    $foldercount = $folderContent | Measure-Object –Line | select Lines
 
 
     # Go through the valid blob storage accounts and confirm Anonymous Access / List files
     foreach ($subDomain in $runningList){
         
         $iter = 0
-
-        # Read in file
-        $folderContent = Get-Content $Folders
-
-        # Append any Bing results
-        $folderContent += ($bingContainers | select -Unique)
-        
 
         # Folder Names to guess for containers
         foreach ($folderName in $folderContent){
@@ -206,10 +205,10 @@ $lookupResult = ""
                     $FileList = (Invoke-WebRequest -uri $uriList -Headers @{"x-ms-version"="2019-12-12"} -Method Get).Content
                     # Microsoft includes these characters in the response, Thanks...
                     [xml]$xmlFileList = $FileList -replace "ï»¿"
-                    $foundURL = $xmlFileList.EnumerationResults.Blobs.Blob
+                    $foundURL = @($xmlFileList.EnumerationResults.Blobs.Blob)
 
                     # Parse the XML results
-                    if($foundURL.Length -gt 1){
+                    if($foundURL.Count -gt 0){
                         foreach($url in $foundURL){
                             if($null -ne $url.VersionId){
                                 $dateTime = Get-Date ([DateTime]$url.VersionId).ToUniversalTime() -UFormat %s


### PR DESCRIPTION
This PR (1) correctly handles single-file public containers for Azure Blob Storage and (2) updates input file line counting logic to correctly handle empty lines at the end of the file (permutations.txt). 

For (1), the current script will print `Empty Public Container Available:` for a public Azure Blob Storage container with a single file. The fix wraps the XML response in an array to ensure that `$foundUrl` is a single-element `Object[]` rather than a single `XmlElement` (whose `.Length` property would be `$null`) when there is only one file in the container. 

For (2), calls to `Write-Progress` will error when there are empty lines anywhere in $Permutations or $Folders as the words iterator will exceed the line count calculation. This results in a value >100 getting passed to the -PercentComplete parameter. 